### PR TITLE
Edit manifest to be compatible with other shells.

### DIFF
--- a/manifests/fubar.yml
+++ b/manifests/fubar.yml
@@ -1,4 +1,4 @@
-name: (( concat $USER "-fubar" ))
+name: (( echo "${USER}-fubar" ))
 
 instance_groups:
   - name: proxy


### PR DESCRIPTION
concat is not available in vagrant by default.